### PR TITLE
feat: add portfolio processing script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,21 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "inquirer": "^8.2.6"
+        "inquirer": "^8.2.6",
+        "yahoo-finance2": "^2.13.3"
       }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.32.35",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.35.tgz",
+      "integrity": "sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -431,6 +444,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -444,6 +484,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
@@ -573,6 +619,33 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie-file-store": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie-file-store/-/tough-cookie-file-store-2.0.3.tgz",
+      "integrity": "sha512-sMpZVcmFf6EYFHFFl+SYH4W1/OnXBYMGDsv2IlbQ2caHyFElW/UR/gpj/KYU1JwmP4dE9xqwv2+vWcmlXHojSw==",
+      "license": "MIT",
+      "dependencies": {
+        "tough-cookie": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -589,6 +662,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -618,6 +710,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yahoo-finance2": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/yahoo-finance2/-/yahoo-finance2-2.13.3.tgz",
+      "integrity": "sha512-ZECy6wQ7ymT08nVrxqQf+gwmINJ4/ECLyq+vM3SQmH3HWzje5DX1WX5YcZpWpWi4KXdmo2Vuk9OAdrTP09nE4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.32.27",
+        "@types/tough-cookie": "^4.0.2",
+        "tough-cookie": "^4.1.2",
+        "tough-cookie-file-store": "^2.0.3"
+      },
+      "bin": {
+        "yahoo-finance": "bin/yahoo-finance.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "inquirer": "^8.2.6"
+    "inquirer": "^8.2.6",
+    "yahoo-finance2": "^2.13.3"
   }
 }

--- a/processPortfolio.js
+++ b/processPortfolio.js
@@ -1,0 +1,119 @@
+const path = require('path');
+const readline = require('readline');
+const yahooFinance = require('yahoo-finance2').default;
+const { setDataDir, loadPortfolio, savePortfolio, appendTradeLog } = require('./data/csvStore');
+
+async function ask(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise(resolve => rl.question(question, ans => { rl.close(); resolve(ans); }));
+}
+
+async function processPortfolio(portfolio, startingCash, dataDir = path.join(__dirname, 'Scripts and CSV Files')) {
+  setDataDir(dataDir);
+  const today = new Date().toISOString().slice(0, 10);
+  const day = new Date().getDay();
+
+  if (day === 0 || day === 6) {
+    const response = await ask(`Today is currently a weekend, so markets were never open.\nThis will cause the program to calculate data from the last day (usually Friday), and save it as today.\nAre you sure you want to do this? To exit, enter 1.`);
+    if (response.trim() === '1') throw new Error('Exiting program.');
+  }
+
+  const results = [];
+  let totalValue = 0;
+  let totalPnL = 0;
+  let cash = startingCash;
+  const remaining = [];
+
+  for (const stock of portfolio) {
+    const ticker = stock.ticker;
+    const shares = Number(stock.shares);
+    const cost = Number(stock.buy_price);
+    const stop = Number(stock.stop_loss);
+    let price;
+    try {
+      const quote = await yahooFinance.quote(ticker);
+      price = typeof quote.regularMarketPrice === 'number' ? quote.regularMarketPrice : NaN;
+    } catch {
+      price = NaN;
+    }
+
+    if (!price) {
+      results.push({
+        Date: today,
+        Ticker: ticker,
+        Shares: shares,
+        'Cost Basis': cost,
+        'Stop Loss': stop,
+        'Current Price': '',
+        'Total Value': '',
+        PnL: '',
+        Action: 'NO DATA',
+        'Cash Balance': '',
+        'Total Equity': '',
+      });
+      continue;
+    }
+
+    price = Number(price.toFixed(2));
+    const value = Number((price * shares).toFixed(2));
+    const pnl = Number(((price - cost) * shares).toFixed(2));
+    let action = 'HOLD';
+
+    if (price <= stop) {
+      action = 'SELL - Stop Loss Triggered';
+      cash += value;
+      await appendTradeLog({
+        Date: today,
+        Ticker: ticker,
+        'Shares Bought': '',
+        'Buy Price': '',
+        'Cost Basis': cost,
+        PnL: pnl,
+        Reason: 'AUTOMATED SELL - STOPLOSS TRIGGERED',
+        'Shares Sold': shares,
+        'Sell Price': price,
+      });
+    } else {
+      totalValue += value;
+      totalPnL += pnl;
+      remaining.push(stock);
+    }
+
+    results.push({
+      Date: today,
+      Ticker: ticker,
+      Shares: shares,
+      'Cost Basis': cost,
+      'Stop Loss': stop,
+      'Current Price': price,
+      'Total Value': value,
+      PnL: pnl,
+      Action: action,
+      'Cash Balance': '',
+      'Total Equity': '',
+    });
+  }
+
+  const totalRow = {
+    Date: today,
+    Ticker: 'TOTAL',
+    Shares: '',
+    'Cost Basis': '',
+    'Stop Loss': '',
+    'Current Price': '',
+    'Total Value': totalValue.toFixed(2),
+    PnL: totalPnL.toFixed(2),
+    Action: '',
+    'Cash Balance': cash.toFixed(2),
+    'Total Equity': (cash + totalValue).toFixed(2),
+  };
+  results.push(totalRow);
+
+  let existing = await loadPortfolio();
+  existing = existing.filter(r => r.Date !== today);
+  await savePortfolio(existing.concat(results));
+
+  return { portfolio: remaining, cash };
+}
+
+module.exports = processPortfolio;


### PR DESCRIPTION
## Summary
- add `processPortfolio.js` to update holdings, log trades, and write daily results
- integrate `yahoo-finance2` for market quotes and stop-loss checks
- include weekend safeguard mirroring Python utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ff2f5313083239cca91f02a5bc059