### PR TITLE
feat: add cli entry point

### DIFF
--- a/cli/manualTrades.js
+++ b/cli/manualTrades.js
@@ -2,8 +2,16 @@ const fs = require('fs');
 const path = require('path');
 const inquirer = require('inquirer');
 
-const portfolioPath = path.join(__dirname, '..', 'Scripts and CSV Files', 'chatgpt_portfolio_update.csv');
-const tradeLogPath = path.join(__dirname, '..', 'Scripts and CSV Files', 'chatgpt_trade_log.csv');
+let DATA_DIR = path.join(__dirname, '..', 'Scripts and CSV Files');
+let portfolioPath = path.join(DATA_DIR, 'chatgpt_portfolio_update.csv');
+let tradeLogPath = path.join(DATA_DIR, 'chatgpt_trade_log.csv');
+
+function setDataDir(dir) {
+  DATA_DIR = path.resolve(dir);
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+  portfolioPath = path.join(DATA_DIR, 'chatgpt_portfolio_update.csv');
+  tradeLogPath = path.join(DATA_DIR, 'chatgpt_trade_log.csv');
+}
 
 function loadPortfolio() {
   const text = fs.readFileSync(portfolioPath, 'utf8').trim();
@@ -174,4 +182,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { logManualBuy, logManualSell };
+module.exports = { logManualBuy, logManualSell, main, setDataDir };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,70 @@
+const path = require('path');
+const processPortfolio = require('./processPortfolio');
+const dailyResults = require('./dailyResults');
+const { setDataDir, loadPortfolio } = require('./data/csvStore');
+const { main: manualMain, setDataDir: setManualDir } = require('./cli/manualTrades');
+
+async function loadCurrentPortfolio(dataDir) {
+  setDataDir(dataDir);
+  const rows = await loadPortfolio();
+  if (!rows.length) return { holdings: [], cash: 0 };
+  const dates = [...new Set(rows.map(r => r.Date))].sort();
+  const latest = dates[dates.length - 1];
+  const holdingsRows = rows.filter(r => r.Date === latest && r.Ticker !== 'TOTAL');
+  const totalRow = rows.find(r => r.Date === latest && r.Ticker === 'TOTAL') || {};
+  const holdings = holdingsRows.map(r => ({
+    ticker: r.Ticker,
+    shares: Number(r.Shares),
+    buy_price: Number(r['Cost Basis']),
+    stop_loss: Number(r['Stop Loss'])
+  }));
+  const cash = Number(totalRow['Cash Balance'] || 0);
+  return { holdings, cash };
+}
+
+async function runPortfolio(startingCash, dataDir) {
+  const { holdings, cash } = await loadCurrentPortfolio(dataDir);
+  const initialCash = typeof startingCash === 'number' ? startingCash : cash;
+  const result = await processPortfolio(holdings, initialCash, dataDir);
+  await dailyResults(dataDir);
+  return result;
+}
+
+async function runManual(dataDir) {
+  if (setManualDir) setManualDir(dataDir);
+  await manualMain();
+}
+
+function parseArgs(argv) {
+  const opts = { manual: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--cash' || a === '-c') {
+      opts.cash = parseFloat(argv[++i]);
+    } else if (a === '--data' || a === '-d') {
+      opts.dataDir = argv[++i];
+    } else if (a === '--manual' || a === '-m') {
+      opts.manual = true;
+    }
+  }
+  return opts;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const dataDir = args.dataDir || path.join(__dirname, 'Scripts and CSV Files');
+  if (args.manual) {
+    await runManual(dataDir);
+  } else {
+    await runPortfolio(args.cash, dataDir);
+  }
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = { main, runPortfolio, runManual, loadCurrentPortfolio };


### PR DESCRIPTION
## Summary
- add index.js to parse CLI options, process portfolio, run results, or launch manual trade prompts
- allow manual trade script to use custom data directory and export a main function

## Testing
- `npm test`
- `node index.js --cash 100 --data data`


------
https://chatgpt.com/codex/tasks/task_e_688ff772c1a883239e5ed1dea1d60cc7