### PR TITLE
feat: document automation and non-interactive mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY . .
+CMD ["node", "index.js", "--no-interactive"]

--- a/README.md
+++ b/README.md
@@ -79,3 +79,69 @@ One final shameless plug: (https://substack.com/@nathanbsmith?utm_source=edit-pr
 
 Find a mistake in the logs or have advice?
 Please Reach out here: nathanbsmith.business@gmail.com
+
+## Automation & Deployment
+
+### Non-interactive Mode
+
+Run the daily portfolio update without any prompts by passing `--no-interactive`:
+
+```bash
+node index.js --no-interactive
+```
+
+Use `--data` or the `DATA_DIR` environment variable to choose where CSV files are stored:
+
+```bash
+DATA_DIR=/path/to/data node index.js --no-interactive
+```
+
+### Scheduling
+
+#### Using cron
+
+Schedule the script on a Linux server with `crontab -e`:
+
+```
+0 20 * * 1-5 /usr/bin/node /opt/app/index.js --no-interactive >> /var/log/portfolio.log 2>&1
+```
+
+This example runs at 8 PM Monday–Friday.
+
+#### Using node-cron
+
+Add [node-cron](https://www.npmjs.com/package/node-cron) and create a small wrapper:
+
+```js
+const cron = require('node-cron');
+const { main } = require('./index');
+
+cron.schedule('0 20 * * 1-5', () => main(['--no-interactive']));
+```
+
+### Environment Variables
+
+Configuration can be supplied via environment variables:
+
+- `DATA_DIR` – directory for CSV data (defaults to `Scripts and CSV Files`).
+- `API_KEY` – placeholder for any future data-provider keys.
+
+Set them in your shell or via a `.env` file:
+
+```bash
+export DATA_DIR=/data/chatgpt
+export API_KEY=your-key-here
+```
+
+### Containerization
+
+A minimal `Dockerfile` is included for deployment on a VPS or PaaS.
+
+Build and run the image:
+
+```bash
+docker build -t micro-cap .
+docker run -e DATA_DIR=/data -v $(pwd)/data:/data micro-cap
+```
+
+Use the platform's scheduler (e.g., cron, Kubernetes CronJob, PaaS tasks) to trigger the container at your desired interval.

--- a/index.js
+++ b/index.js
@@ -22,10 +22,11 @@ async function loadCurrentPortfolio(dataDir) {
   return { holdings, cash };
 }
 
-async function runPortfolio(startingCash, dataDir) {
+async function runPortfolio(startingCash, dataDir, opts = {}) {
+  const { interactive = true } = opts;
   const { holdings, cash } = await loadCurrentPortfolio(dataDir);
   const initialCash = typeof startingCash === 'number' ? startingCash : cash;
-  const result = await processPortfolio(holdings, initialCash, dataDir);
+  const result = await processPortfolio(holdings, initialCash, dataDir, { interactive });
   await dailyResults(dataDir);
   return result;
 }
@@ -36,7 +37,7 @@ async function runManual(dataDir) {
 }
 
 function parseArgs(argv) {
-  const opts = { manual: false };
+  const opts = { manual: false, interactive: true };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--cash' || a === '-c') {
@@ -45,6 +46,8 @@ function parseArgs(argv) {
       opts.dataDir = argv[++i];
     } else if (a === '--manual' || a === '-m') {
       opts.manual = true;
+    } else if (a === '--no-interactive' || a === '-n') {
+      opts.interactive = false;
     }
   }
   return opts;
@@ -52,11 +55,11 @@ function parseArgs(argv) {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const dataDir = args.dataDir || path.join(__dirname, 'Scripts and CSV Files');
+  const dataDir = args.dataDir || process.env.DATA_DIR || path.join(__dirname, 'Scripts and CSV Files');
   if (args.manual) {
     await runManual(dataDir);
   } else {
-    await runPortfolio(args.cash, dataDir);
+    await runPortfolio(args.cash, dataDir, { interactive: args.interactive });
   }
 }
 

--- a/processPortfolio.js
+++ b/processPortfolio.js
@@ -8,14 +8,17 @@ async function ask(question) {
   return new Promise(resolve => rl.question(question, ans => { rl.close(); resolve(ans); }));
 }
 
-async function processPortfolio(portfolio, startingCash, dataDir = path.join(__dirname, 'Scripts and CSV Files')) {
+async function processPortfolio(portfolio, startingCash, dataDir = path.join(__dirname, 'Scripts and CSV Files'), opts = {}) {
+  const { interactive = true } = opts;
   setDataDir(dataDir);
   const today = new Date().toISOString().slice(0, 10);
   const day = new Date().getDay();
 
   if (day === 0 || day === 6) {
-    const response = await ask(`Today is currently a weekend, so markets were never open.\nThis will cause the program to calculate data from the last day (usually Friday), and save it as today.\nAre you sure you want to do this? To exit, enter 1.`);
-    if (response.trim() === '1') throw new Error('Exiting program.');
+    if (interactive) {
+      const response = await ask(`Today is currently a weekend, so markets were never open.\nThis will cause the program to calculate data from the last day (usually Friday), and save it as today.\nAre you sure you want to do this? To exit, enter 1.`);
+      if (response.trim() === '1') throw new Error('Exiting program.');
+    }
   }
 
   const results = [];


### PR DESCRIPTION
## Summary
- add `--no-interactive` flag and env-driven data directory
- document scheduling, env vars, and containerization
- include Dockerfile for deployment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ff8d911348323aac532a26cf217b7